### PR TITLE
Handle duplicate names in delete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,19 +132,23 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
-### Deleting a person : `delete`
+### Deleting an employee : `delete`
 
-Deletes the specified person from the address book.
+Deletes the specified employee from the address book.
 
-Format: `delete INDEX`
+Format: `delete NAME` or `delete INDEX`
 
-* Deletes the person at the specified `INDEX`.
-* The index refers to the index number shown in the displayed person list.
+* `delete INDEX` deletes the employee at the specified `INDEX`.
+* The index refers to the index number shown in the displayed employee list.
 * The index **must be a positive integer** 1, 2, 3, …​
+* `delete NAME` deletes the employee whose name matches `NAME`, ignoring case and extra spaces.
+* `delete NAME` works only when exactly one employee matches the given name.
+* If multiple employees share the same name, use `delete INDEX` instead.
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd person in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+* `list` followed by `delete 2` deletes the 2nd employee in the address book.
+* `find Betsy` followed by `delete 1` deletes the 1st employee in the results of the `find` command.
+* `delete John Doe` deletes the employee named `John Doe` if the name is unique in the current list.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -25,6 +25,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_EMPLOYEE_SUCCESS = "Deleted Employee: %1$s";
     public static final String MESSAGE_INVALID_NAME = "Name must contain only alphabets and optional '/'.";
     public static final String MESSAGE_EMPLOYEE_NOT_FOUND = "Employee with name '%1$s' does not exist.";
+    public static final String MESSAGE_DUPLICATE_EMPLOYEE_NAME =
+            "Multiple employees named '%1$s' found. Please use the index instead.";
     public static final String MESSAGE_INVALID_INDEX = "The employee index provided is invalid.";
 
     private final Integer targetIndex; // null if not used
@@ -70,6 +72,7 @@ public class DeleteCommand extends Command {
             // Name-based deletion
             requireNonNull(targetName);
             String normalizedTarget = normalizeName(targetName);
+            int matchCount = 0;
             if (!isValidName(normalizedTarget)) {
                 throw new CommandException(MESSAGE_INVALID_NAME);
             }
@@ -77,12 +80,16 @@ public class DeleteCommand extends Command {
                 String employeeName = normalizeName(employee.getName().fullName);
                 if (employeeName.equals(normalizedTarget)) {
                     personToDelete = employee;
-                    break;
+                    matchCount++;
                 }
             }
-            if (personToDelete == null) {
+            if (matchCount == 0) {
                 throw new CommandException(
                         String.format(MESSAGE_EMPLOYEE_NOT_FOUND, targetName));
+            }
+            if (matchCount > 1) {
+                throw new CommandException(
+                        String.format(MESSAGE_DUPLICATE_EMPLOYEE_NAME, targetName));
             }
         }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.employee.Employee;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -50,6 +51,23 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_duplicateNameUnfilteredList_throwsCommandException() {
+        Model duplicateModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        String duplicateName = "Same Name";
+        Employee firstDuplicate = new PersonBuilder().withName(duplicateName)
+                .withPhone("11111111").withEmail("same1@example.com").build();
+        Employee secondDuplicate = new PersonBuilder().withName(duplicateName)
+                .withPhone("22222222").withEmail("same2@example.com").build();
+        duplicateModel.addPerson(firstDuplicate);
+        duplicateModel.addPerson(secondDuplicate);
+
+        DeleteCommand deleteCommand = new DeleteCommand(duplicateName);
+
+        assertCommandFailure(deleteCommand, duplicateModel,
+                String.format(DeleteCommand.MESSAGE_DUPLICATE_EMPLOYEE_NAME, duplicateName));
+    }
+
+    @Test
     public void execute_validNameFilteredList_success() {
         Employee personToDelete = model.getFilteredPersonList().get(0);
         showPersonByName(model, personToDelete.getName().fullName);
@@ -65,6 +83,24 @@ public class DeleteCommandTest {
         showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateNameFilteredList_throwsCommandException() {
+        Model duplicateModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        String duplicateName = "Same Name";
+        Employee firstDuplicate = new PersonBuilder().withName(duplicateName)
+                .withPhone("11111111").withEmail("same1@example.com").build();
+        Employee secondDuplicate = new PersonBuilder().withName(duplicateName)
+                .withPhone("22222222").withEmail("same2@example.com").build();
+        duplicateModel.addPerson(firstDuplicate);
+        duplicateModel.addPerson(secondDuplicate);
+        duplicateModel.updateFilteredPersonList(employee -> employee.getName().fullName.equals(duplicateName));
+
+        DeleteCommand deleteCommand = new DeleteCommand(duplicateName);
+
+        assertCommandFailure(deleteCommand, duplicateModel,
+                String.format(DeleteCommand.MESSAGE_DUPLICATE_EMPLOYEE_NAME, duplicateName));
     }
 
     @Test


### PR DESCRIPTION
Closes #48 

## Summary
Prevents `delete NAME` from silently deleting the first match when multiple employees share the same name.

## Changes
- detect duplicate name matches in `DeleteCommand`
- throw a clear error asking the user to use index instead
- preserve existing behavior for unique matches and missing names
- add tests for duplicate-name cases
- update the User Guide for `delete NAME`

## Testing
- ./gradlew test --tests seedu.address.logic.commands.DeleteCommandTest --tests seedu.address.logic.parser.DeleteCommandParserTest
- ./gradlew check coverage
