### PR TITLE
Update ManageUp user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -20,11 +20,12 @@ contact details, roles, departments, and assigned tasks more efficiently.
 1. Ensure you have Java `17` or above installed in your Computer.<br>
    **Mac users:** Ensure you have the precise JDK version prescribed [here](https://se-education.org/guides/tutorials/javaInstallationMac.html).
 
-1. Download the latest `.jar` file from [here](https://github.com/se-edu/addressbook-level3/releases).
+1. Download the latest `.jar` file from the ManageUp GitHub releases page.
 
 1. Copy the file to the folder you want to use as the _home folder_ for ManageUp.
 
-1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar addressbook.jar` command to run the application.<br>
+1. Open a command terminal, `cd` into the folder you put the jar file in, and use the
+   `java -jar ManageUp.jar` command to run the application.<br>
    A GUI similar to the below should appear in a few seconds. Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Closes #57 

## Summary
Updates the User Guide to match the current ManageUp features and terminology.

## Changes
- replace outdated AB3/contact wording with ManageUp branding
- update `add`, `edit`, `find`, `list`, and `delete` documentation
- document `show`
- document `addtask`
- update quick start examples and command summary
- leave unfinished task commands out of the guide for now
