### PR TITLE
Add case-insensitive name comparison in AddCommand and EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -90,7 +90,7 @@ public class EditCommand extends Command {
         Employee personToEdit = lastShownList.get(index.getZeroBased());
         Employee editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        if (!personToEdit.isSameEmployee(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -15,7 +15,7 @@ import seedu.address.storage.TaskList;
 
 /**
  * Wraps all data at the address-book level
- * Duplicates are not allowed (by .isSamePerson comparison)
+ * Duplicates are not allowed (by .isSameEmployee comparison)
  */
 public class AddressBook implements ReadOnlyAddressBook {
 

--- a/src/main/java/seedu/address/model/employee/Department.java
+++ b/src/main/java/seedu/address/model/employee/Department.java
@@ -31,7 +31,7 @@ public class Department {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid department.
      */
     public static boolean isValidDepartment(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/employee/Email.java
+++ b/src/main/java/seedu/address/model/employee/Email.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Employee's email in the address book.
+ * Represents an Employee's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {

--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -73,18 +73,23 @@ public class Employee {
     }
 
     /**
-     * Returns true if both employees have the same name.
-     * This defines a weaker notion of equality between two persons.
+     * Returns true if both employees have the same name (case-insensitive) and
+     * same phone or same email.
      */
-    public boolean isSamePerson(Employee otherPerson) {
+    public boolean isSameEmployee(Employee otherPerson) {
+        if (otherPerson == null) {
+            return false;
+        }
+
         if (otherPerson == this) {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getName().equals(getName())
-                && (otherPerson.getPhone().equals(getPhone())
-                || otherPerson.getEmail().equals(getEmail()));
+        boolean isSameName = name.equalsIgnoreCase(otherPerson.getName());
+        boolean isSamePhone = phone.equals(otherPerson.phone);
+        boolean isSameEmail = email.equals(otherPerson.email);
+
+        return isSameName && (isSamePhone || isSameEmail);
     }
 
     /**

--- a/src/main/java/seedu/address/model/employee/Name.java
+++ b/src/main/java/seedu/address/model/employee/Name.java
@@ -59,6 +59,16 @@ public class Name {
         return fullName.equals(otherName.fullName);
     }
 
+    /**
+     * Returns true if both names represent the same name, ignoring differences in letter casing.
+     */
+    public boolean equalsIgnoreCase(Name other) {
+        if (other == this) {
+            return true;
+        }
+        return other != null && fullName.equalsIgnoreCase(other.fullName);
+    }
+
     @Override
     public int hashCode() {
         return fullName.hashCode();

--- a/src/main/java/seedu/address/model/employee/Phone.java
+++ b/src/main/java/seedu/address/model/employee/Phone.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Employee's phone number in the address book.
+ * Represents an Employee's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
 public class Phone {

--- a/src/main/java/seedu/address/model/employee/Position.java
+++ b/src/main/java/seedu/address/model/employee/Position.java
@@ -19,7 +19,7 @@ public class Position {
     /**
      * Constructs a {@code Position}.
      *
-     * @param value A valid value
+     * @param value A valid Position
      */
     public Position(String value) {
         requireNonNull(value);
@@ -28,7 +28,7 @@ public class Position {
     }
 
     /**
-     * Returns true if a given string is a valid value.
+     * Returns true if a given string is a valid Position.
      */
     public static boolean isValidPosition(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/employee/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/employee/UniquePersonList.java
@@ -13,14 +13,14 @@ import seedu.address.model.employee.exceptions.PersonNotFoundException;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
- * A person is considered unique by comparing using {@code Employee#isSamePerson(Employee)}. As such, adding and
- * updating of persons uses Employee#isSamePerson(Employee) for equality so as to ensure that the person being added
+ * A person is considered unique by comparing using {@code Employee#isSameEmployee(Employee)}. As such, adding and
+ * updating of persons uses Employee#isSameEmployee(Employee) for equality so as to ensure that the person being added
  * or updated is unique in terms of identity in the UniquePersonList. However, the removal of a person uses
  * Employee#equals(Object) so as to ensure that the person with exactly the same fields will be removed.
  * <p>
  * Supports a minimal set of list operations.
  *
- * @see Employee#isSamePerson(Employee)
+ * @see Employee#isSameEmployee(Employee)
  */
 public class UniquePersonList implements Iterable<Employee> {
 
@@ -33,7 +33,7 @@ public class UniquePersonList implements Iterable<Employee> {
      */
     public boolean contains(Employee toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSamePerson);
+        return internalList.stream().anyMatch(toCheck::isSameEmployee);
     }
 
     /**
@@ -61,7 +61,7 @@ public class UniquePersonList implements Iterable<Employee> {
             throw new PersonNotFoundException();
         }
 
-        if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
+        if (!target.isSameEmployee(editedPerson) && contains(editedPerson)) {
             throw new DuplicatePersonException();
         }
 
@@ -140,7 +140,7 @@ public class UniquePersonList implements Iterable<Employee> {
     private boolean personsAreUnique(List<Employee> persons) {
         for (int i = 0; i < persons.size() - 1; i++) {
             for (int j = i + 1; j < persons.size(); j++) {
-                if (persons.get(i).isSamePerson(persons.get(j))) {
+                if (persons.get(i).isSameEmployee(persons.get(j))) {
                     return false;
                 }
             }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -55,6 +55,27 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_duplicateEmployeeCaseInsensitive_throwsCommandException() {
+        Employee existingPerson = new PersonBuilder().withName("John Doe")
+                                                     .withPhone("12345678")
+                                                     .withEmail("john@email.com")
+                                                     .build();
+
+        Employee samePersonDifferentCase = new PersonBuilder().withName("john doe")
+                                                              .withPhone("12345678")
+                                                              .withEmail("john@email.com")
+                                                              .build();
+
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+        modelStub.personsAdded.add(existingPerson);
+
+        AddCommand addCommand = new AddCommand(samePersonDifferentCase);
+
+        assertThrows(CommandException.class,
+                AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Employee alice = new PersonBuilder().withName("Alice").build();
         Employee bob = new PersonBuilder().withName("Bob").build();
@@ -217,7 +238,7 @@ public class AddCommandTest {
         @Override
         public boolean hasPerson(Employee person) {
             requireNonNull(person);
-            return this.person.isSamePerson(person);
+            return this.person.isSameEmployee(person);
         }
 
         @Override
@@ -240,7 +261,7 @@ public class AddCommandTest {
         @Override
         public boolean hasPerson(Employee person) {
             requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
+            return personsAdded.stream().anyMatch(person::isSameEmployee);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -148,47 +148,61 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateEmail_failure() {
-        Employee firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Employee secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Employee employee = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
 
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withEmail(secondPerson.getEmail().value)
+                .withEmail(employee.getEmail().value)
                 .build();
 
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model,
-                String.format(EditCommand.MESSAGE_DUPLICATE_EMAIL, Messages.format(secondPerson)));
+                String.format(EditCommand.MESSAGE_DUPLICATE_EMAIL, Messages.format(employee)));
     }
 
     @Test
     public void execute_duplicatePhone_failure() {
-        Employee firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Employee secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Employee employee = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withPhone(secondPerson.getPhone().value)
+                .withPhone(employee.getPhone().value)
                 .build();
 
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model,
-                String.format(EditCommand.MESSAGE_DUPLICATE_PHONE, Messages.format(secondPerson)));
+                String.format(EditCommand.MESSAGE_DUPLICATE_PHONE, Messages.format(employee)));
+    }
+
+    @Test
+    public void execute_duplicatePersonCaseInsensitive_failure() {
+        Employee employee = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        String lowerCaseName = employee.getName().fullName.toLowerCase();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withName(lowerCaseName)
+                .withPhone(employee.getPhone().value)
+                .build();
+
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_sameEmailSamePerson_success() {
-        Employee person = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Employee employee = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
-                .withEmail(person.getEmail().value)
+                .withEmail(employee.getEmail().value)
                 .build();
 
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
-                Messages.format(person));
+                Messages.format(employee));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 

--- a/src/test/java/seedu/address/model/employee/NameTest.java
+++ b/src/test/java/seedu/address/model/employee/NameTest.java
@@ -57,4 +57,22 @@ public class NameTest {
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
     }
+
+    @Test
+    public void equalsIgnoreCase() {
+        Name name = new Name("John Doe");
+
+        // same values, different casing -> true
+        assertTrue(name.equalsIgnoreCase(new Name("john doe")));
+
+        // same object -> true
+        assertTrue(name.equalsIgnoreCase(name));
+
+        // null -> false
+        assertFalse(name.equalsIgnoreCase(null));
+
+        // different values -> false
+        assertFalse(name.equalsIgnoreCase(new Name("Jane Doe")));
+    }
+
 }

--- a/src/test/java/seedu/address/model/employee/PersonTest.java
+++ b/src/test/java/seedu/address/model/employee/PersonTest.java
@@ -27,36 +27,36 @@ public class PersonTest {
     @Test
     public void isSamePerson() {
         // same object -> returns true
-        assertTrue(ALICE.isSamePerson(ALICE));
+        assertTrue(ALICE.isSameEmployee(ALICE));
 
         // null -> returns false
-        assertFalse(ALICE.isSamePerson(null));
+        assertFalse(ALICE.isSameEmployee(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Employee editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withPosition(VALID_POSITION_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertFalse(ALICE.isSameEmployee(editedAlice));
 
         // same name, different phone, same email -> returns true
         editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
-        assertTrue(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSameEmployee(editedAlice));
 
         // same name, different phone, different email -> returns false
         editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertFalse(ALICE.isSameEmployee(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertFalse(ALICE.isSameEmployee(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Employee editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSameEmployee(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertFalse(BOB.isSameEmployee(editedBob));
     }
 
     @Test


### PR DESCRIPTION
### Summary
Make employee duplicate detection case-insensitive for names.

### Old Behaviour
Employees with the same name but different casing (e.g., "John Doe" vs "john doe"), with same emails or same phone numbers were treated as different employees.  

This caused inaccurate error messages being displayed such as duplicate phone/email instead of duplicate person.

- Adding `john doe` with the same phone/email as `John Doe`:
  -  Not detected as duplicate person
  -  Triggers `MESSAGE_DUPLICATE_PHONE` / `MESSAGE_DUPLICATE_EMAIL`
  -  Should trigger `MESSAGE_DUPLICATE_PERSON`

- Editing an employee to match another employee’s name (case-insensitive) and phone/email:
  -  Not detected as duplicate person
  -  Triggers `MESSAGE_DUPLICATE_PHONE` / `MESSAGE_DUPLICATE_EMAIL`
  -  Should trigger `MESSAGE_DUPLICATE_PERSON`

### Changes
- Added `equalsIgnoreCase` method in `Name`
- Updated `Employee#isSamePerson` to use case-insensitive name comparison

### Current Behaviour
Employees with the same name (ignoring case) and same phone or email are correctly identified as duplicates and trigger `MESSAGE_DUPLICATE_PERSON`.