### PR TITLE
Fix alpha-bug for AddCommand

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,11 +14,17 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The employee index provided is invalid";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d employees listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_TASK_COMMAND_FORMAT = "Invalid task command format! \n%1$s";
+    public static final String MESSAGE_DUPLICATE_EMPLOYEE =
+            "This employee already exists in the application.";
+    public static final String MESSAGE_DUPLICATE_PHONE =
+            "Phone number is already assigned to another employee:\n%1$s";
+    public static final String MESSAGE_DUPLICATE_EMAIL =
+            "Email is already assigned to another employee:\n%1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -42,6 +48,8 @@ public class Messages {
                 .append(person.getPhone())
                 .append("; Email: ")
                 .append(person.getEmail())
+                .append("; Department: ")
+                .append(person.getDepartment())
                 .append("; Position: ")
                 .append(person.getPosition())
                 .append("; Tags: ");

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.Model;
 import seedu.address.model.employee.Employee;
 
 /**
- * Adds a person to the address book.
+ * Adds an employee to the application.
  */
 public class AddCommand extends Command {
 
@@ -39,11 +39,6 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New employee added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This employee already exists in the address book";
-    public static final String MESSAGE_DUPLICATE_PHONE =
-            "Phone number is already assigned to another employee: %1$s";
-    public static final String MESSAGE_DUPLICATE_EMAIL =
-            "Email is already assigned to another employee: %1$s";
 
     private final Employee toAdd;
 
@@ -60,18 +55,20 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_EMPLOYEE);
         }
 
         Employee employeeWithSamePhone = model.getEmployeeWithSamePhone(toAdd);
         Employee employeeWithSameEmail = model.getEmployeeWithSameEmail(toAdd);
 
         if (employeeWithSameEmail != null) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_EMAIL, Messages.format(employeeWithSameEmail)));
+            throw new CommandException(String.format(Messages.MESSAGE_DUPLICATE_EMAIL,
+                                       Messages.format(employeeWithSameEmail)));
         }
 
         if (employeeWithSamePhone != null) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_PHONE, Messages.format(employeeWithSamePhone)));
+            throw new CommandException(String.format(Messages.MESSAGE_DUPLICATE_PHONE,
+                                       Messages.format(employeeWithSamePhone)));
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -39,7 +39,7 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the employee identified "
             + "by the index number used in the displayed employee list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
@@ -53,15 +53,8 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Employee: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
-    public static final String MESSAGE_DUPLICATE_PHONE =
-            "Phone number is already assigned to another employee: %1$s";
-    public static final String MESSAGE_DUPLICATE_EMAIL =
-            "Email is already assigned to another employee: %1$s";
-
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Employee:\n%1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one employee field to edit must be provided.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -91,18 +84,20 @@ public class EditCommand extends Command {
         Employee editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSameEmployee(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_EMPLOYEE);
         }
 
         Employee employeeWithSamePhone = model.getEmployeeWithSamePhone(editedPerson);
         Employee employeeWithSameEmail = model.getEmployeeWithSameEmail(editedPerson);
 
         if (employeeWithSameEmail != null && !employeeWithSameEmail.equals(personToEdit)) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_EMAIL, Messages.format(employeeWithSameEmail)));
+            throw new CommandException(String.format(Messages.MESSAGE_DUPLICATE_EMAIL,
+                                       Messages.format(employeeWithSameEmail)));
         }
 
         if (employeeWithSamePhone != null && !employeeWithSamePhone.equals(personToEdit)) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_PHONE, Messages.format(employeeWithSamePhone)));
+            throw new CommandException(String.format(Messages.MESSAGE_DUPLICATE_PHONE,
+                                       Messages.format(employeeWithSamePhone)));
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
@@ -32,7 +32,7 @@ public class EditTaskCommand extends Command {
             + PREFIX_TASK_DESCRIPTION + "Follow through with clients ";
 
     public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one task field to edit must be provided.";
     public static final String MESSAGE_INVALID_INDEX = "The task index provided is invalid.";
 
     private final int taskIndex;

--- a/src/main/java/seedu/address/model/employee/Department.java
+++ b/src/main/java/seedu/address/model/employee/Department.java
@@ -8,14 +8,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidDepartment(String)}
  */
 public class Department {
-    public static final String MESSAGE_CONSTRAINTS =
-            "Department should only contain alphanumeric characters and spaces, and it should not be blank";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Department should only contain alphanumeric characters and spaces, "
+                    + "and it should not be blank or exceed 100 characters";
+
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{0,99}";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/employee/Email.java
+++ b/src/main/java/seedu/address/model/employee/Email.java
@@ -15,12 +15,13 @@ public class Email {
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
+            + "2. This is followed by a '@' and then a domain name. The domain name may be a single label "
+            + "(e.g. localhost) or multiple labels separated by periods (e.g. example.com).\n"
             + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
+            + "    - be at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
+            + "3. The total length of the email must not exceed 100 characters.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
@@ -48,6 +49,9 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
+        if (test.length() > 100) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -34,7 +34,7 @@ public class Employee {
      */
     public Employee(Name name, Phone phone, Email email, Department department,
                     Position position, Set<Tag> tags, TaskListStorage taskListStorage) {
-        requireAllNonNull(name, phone, email, position, tags);
+        requireAllNonNull(name, phone, email, department, position, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/model/employee/Name.java
+++ b/src/main/java/seedu/address/model/employee/Name.java
@@ -9,14 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters and spaces, "
+                                                     + "and it should not be blank or exceed 40 characters";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{0,39}";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/employee/Phone.java
+++ b/src/main/java/seedu/address/model/employee/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be 3 to 15 digits long";
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/employee/Position.java
+++ b/src/main/java/seedu/address/model/employee/Position.java
@@ -10,9 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Position {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Positions should only contain alphanumeric characters and spaces, and it should not be blank";
-
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+            "Positions should only contain alphanumeric characters and spaces, "
+                    + "and it should not be blank or exceed 100 characters";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{0,99}";
 
     public final String value;
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -42,7 +42,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Employee personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model,
-                AddCommand.MESSAGE_DUPLICATE_PERSON);
+                Messages.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,7 +51,7 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, Messages.MESSAGE_DUPLICATE_EMPLOYEE, () -> addCommand.execute(modelStub));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(samePersonDifferentCase);
 
         assertThrows(CommandException.class,
-                AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+                Messages.MESSAGE_DUPLICATE_EMPLOYEE, () -> addCommand.execute(modelStub));
     }
 
     @Test
@@ -307,7 +307,7 @@ public class AddCommandTest {
 
         AddCommand addCommand = new AddCommand(personWithSamePhone);
         assertThrows(CommandException.class,
-                String.format(AddCommand.MESSAGE_DUPLICATE_PHONE,
+                String.format(Messages.MESSAGE_DUPLICATE_PHONE,
                               Messages.format(validPerson)), () -> addCommand.execute(modelStub));
     }
 
@@ -323,7 +323,7 @@ public class AddCommandTest {
 
         AddCommand addCommand = new AddCommand(personWithSameEmail);
         assertThrows(CommandException.class,
-                String.format(AddCommand.MESSAGE_DUPLICATE_EMAIL,
+                String.format(Messages.MESSAGE_DUPLICATE_EMAIL,
                               Messages.format(validPerson)), () -> addCommand.execute(modelStub));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -105,7 +105,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model,
-                String.format(EditCommand.MESSAGE_DUPLICATE_EMAIL, Messages.format(employee)));
+                String.format(Messages.MESSAGE_DUPLICATE_EMAIL, Messages.format(employee)));
     }
 
     @Test
@@ -172,7 +172,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model,
-                String.format(EditCommand.MESSAGE_DUPLICATE_PHONE, Messages.format(employee)));
+                String.format(Messages.MESSAGE_DUPLICATE_PHONE, Messages.format(employee)));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class EditCommandTest {
 
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_DUPLICATE_EMPLOYEE);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/employee/DepartmentTest.java
@@ -1,0 +1,53 @@
+package seedu.address.model.employee;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DepartmentTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Department(null));
+    }
+
+    @Test
+    public void constructor_invalidDepartment_throwsIllegalArgumentException() {
+        String invalidDepartment = "";
+        assertThrows(IllegalArgumentException.class, () -> new Department(invalidDepartment));
+    }
+
+    @Test
+    public void isValidDepartment() {
+        // null department
+        assertThrows(NullPointerException.class, () -> Department.isValidDepartment(null));
+
+        // invalid department
+        assertFalse(Department.isValidDepartment("")); // empty string
+        assertFalse(Department.isValidDepartment(" ")); // spaces only
+        assertFalse(Department.isValidDepartment("R&D")); // non-alphanumeric character
+        assertFalse(Department.isValidDepartment("a".repeat(101))); // exceeds 100 characters limit
+
+        // valid department
+        assertTrue(Department.isValidDepartment("IT")); // short value
+        assertTrue(Department.isValidDepartment("Human Resources")); // multiple words
+        assertTrue(Department.isValidDepartment("a".repeat(100))); // exactly 100 characters
+    }
+
+    @Test
+    public void equals() {
+        Department department = new Department("IT");
+
+        assertTrue(department.equals(new Department("IT"))); // same value
+        assertTrue(department.equals(department)); // same object
+        assertFalse(department.equals(null)); // null
+        assertFalse(department.equals(5.0f)); // different type
+        assertFalse(department.equals(new Department("HR"))); // different value
+    }
+
+
+}
+
+

--- a/src/test/java/seedu/address/model/employee/EmailTest.java
+++ b/src/test/java/seedu/address/model/employee/EmailTest.java
@@ -51,6 +51,7 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("a".repeat(89) + "@example.com")); // exactly 101 characters, exceeds limit
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -64,6 +65,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("a".repeat(88) + "@example.com")); // exactly 100 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/NameTest.java
+++ b/src/test/java/seedu/address/model/employee/NameTest.java
@@ -29,13 +29,15 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertTrue(Name.isValidName("a".repeat(40))); // exceeds 41 characters limit
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long name within 40 characters limit
+        assertTrue(Name.isValidName("a".repeat(40))); // exactly 40 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/PhoneTest.java
+++ b/src/test/java/seedu/address/model/employee/PhoneTest.java
@@ -31,11 +31,13 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("9312153412345678")); // 16 digits long, exceeds maximum length of 15
+
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers
+        assertTrue(Phone.isValidPhone("931215341234567")); // exactly 15 numbers
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/PositionTest.java
+++ b/src/test/java/seedu/address/model/employee/PositionTest.java
@@ -1,4 +1,52 @@
 package seedu.address.model.employee;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class PositionTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Position(null));
+    }
+
+    @Test
+    public void constructor_invalidPosition_throwsIllegalArgumentException() {
+        String invalidPosition = "";
+        assertThrows(IllegalArgumentException.class, () -> new Position(invalidPosition));
+    }
+
+    @Test
+    public void isValidPosition() {
+        // null position
+        assertThrows(NullPointerException.class, () -> Position.isValidPosition(null));
+
+        // invalid position
+        assertFalse(Position.isValidPosition("")); // empty string
+        assertFalse(Position.isValidPosition(" ")); // spaces only
+        assertFalse(Position.isValidPosition("Manager!")); // non-alphanumeric character
+        assertFalse(Position.isValidPosition("a".repeat(101))); // exceeds 100 characters limit
+
+        // valid position — single and multiple words
+        assertTrue(Position.isValidPosition("Manager")); // single word
+        assertTrue(Position.isValidPosition("Software Engineer")); // two words
+        assertTrue(Position.isValidPosition("Lead Software Engineer")); // three words
+
+        // valid — within length limit
+        assertTrue(Position.isValidPosition("a".repeat(100))); // exactly 100 characters
+    }
+
+    @Test
+    public void equals() {
+        Position position = new Position("Software Engineer");
+
+        assertTrue(position.equals(new Position("Software Engineer"))); // same value
+        assertTrue(position.equals(position)); // same object
+        assertFalse(position.equals(null)); // null
+        assertFalse(position.equals(5.0f)); // different type
+        assertFalse(position.equals(new Position("Manager"))); // different value
+    }
 }


### PR DESCRIPTION
### Summary
Enforced input length constraints in `add` command to prevent UI truncation:
 - `Name` capped at 40 characters
 - `Email`, `Position`, and `Department` capped at 100 characters

Add input handling for invalid phone numbers
 - `Phone` numbers restricted to 3–15 digits.