### PR TITLE
Fix delete NAME mismatch

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.employee.Employee;
+import seedu.address.model.employee.Name;
 
 /**
  * Deletes an employee identified using their name or index from the address book.
@@ -30,7 +31,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_EMPLOYEE_SUCCESS = "Deleted Employee: %1$s";
     public static final String MESSAGE_DELETE_EMPLOYEES_SUCCESS = "Deleted Employees:\n%1$s";
-    public static final String MESSAGE_INVALID_NAME = "Name must contain only alphabets and optional '/'.";
+    public static final String MESSAGE_INVALID_NAME = Name.MESSAGE_CONSTRAINTS;
     public static final String MESSAGE_EMPLOYEE_NOT_FOUND = "Employee with name '%1$s' does not exist.";
     public static final String MESSAGE_DUPLICATE_EMPLOYEE_NAME =
             "Multiple employees named '%1$s' found. Please use the index instead.";
@@ -169,8 +170,7 @@ public class DeleteCommand extends Command {
      * @return true if valid, false otherwise.
      */
     private boolean isValidName(String name) {
-        // Only alphabets, spaces, and '/'
-        return name.matches("[a-zA-Z /]+");
+        return Name.isValidName(name);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -8,6 +8,7 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.employee.Name;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -41,7 +42,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         } catch (NumberFormatException e) {
             // Not an integer, treat as name
             String normalizedName = trimmedArgs.replaceAll("^ +", " ").replaceAll(" +", " ").toLowerCase();
-            if (!normalizedName.matches("[a-zA-Z /]+")) {
+            if (!Name.isValidName(normalizedName)) {
                 throw new ParseException(DeleteCommand.MESSAGE_INVALID_NAME);
             }
             return new DeleteCommand(trimmedArgs);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -45,6 +45,24 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_validAlphanumericNameUnfilteredList_success() {
+        Model alphanumericModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Employee personToDelete = new PersonBuilder().withName("John2 Doe").withPhone("81112222")
+                .withEmail("john2@example.com").build();
+        alphanumericModel.addPerson(personToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName().fullName);
+        String expectedMessage = String.format(
+                DeleteCommand.MESSAGE_DELETE_EMPLOYEE_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(alphanumericModel.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, alphanumericModel, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_invalidNameUnfilteredList_throwsCommandException() {
         String invalidName = "Nonexistent Employee";
         DeleteCommand deleteCommand = new DeleteCommand(invalidName);

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -25,6 +25,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "John Doe", new DeleteCommand("John Doe"));
+        assertParseSuccess(parser, "John2 Doe", new DeleteCommand("John2 Doe"));
         assertParseSuccess(parser, "1", new DeleteCommand(1));
         assertParseSuccess(parser, "1 3 5", new DeleteCommand(List.of(
                 Index.fromOneBased(1), Index.fromOneBased(3), Index.fromOneBased(5))));
@@ -32,7 +33,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "123abc", DeleteCommand.MESSAGE_INVALID_NAME);
+        assertParseFailure(parser, "John_Doe", DeleteCommand.MESSAGE_INVALID_NAME);
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "0", DeleteCommand.MESSAGE_INVALID_INDEX);
         assertParseFailure(parser, "2 2", DeleteCommand.MESSAGE_DUPLICATE_INDEX);


### PR DESCRIPTION
Fixes the mismatch between employee name validation and `delete NAME` parsing.

Previously, `delete NAME` only accepted alphabetic names, even though valid employee names in ManageUp may contain alphanumeric characters. This caused valid employees such as `John2 Doe` to be undeletable by name.

Summary:
- align `delete NAME` validation with the `Name` model constraints
- reuse `Name.isValidName(...)` in both `DeleteCommand` and `DeleteCommandParser`
- update the invalid-name message to use `Name.MESSAGE_CONSTRAINTS`
- add regression tests for valid alphanumeric delete-by-name input

Result:
- valid alphanumeric employee names can now be deleted by name
- delete-name validation is now consistent with employee-name validation elsewhere in the app

Testing:
- added command test for deleting an employee named `John2 Doe`
- added parser test for valid input `John2 Doe`
- updated parser invalid-input test to use a truly invalid name (`John_Doe`)
- ran focused tests and checkstyle successfully

Closes #127 