### PR TITLE
Fix task constraint in edittask

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
@@ -35,7 +35,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
 
         if (argMultimap.getValue(PREFIX_TASK_NAME).isPresent()) {
             String taskName = argMultimap.getValue(PREFIX_TASK_NAME).get().trim();
-            if (taskName.isEmpty()) {
+            if (taskName.isEmpty() || taskName.length() > 50) {
                 throw new ParseException(Task.MESSAGE_CONSTRAINTS_TASK_NAME);
             }
             editTaskDescriptor.setTaskName(taskName);
@@ -43,7 +43,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
 
         if (argMultimap.getValue(PREFIX_TASK_DESCRIPTION).isPresent()) {
             String taskDescription = argMultimap.getValue(PREFIX_TASK_DESCRIPTION).get().trim();
-            if (taskDescription.isEmpty()) {
+            if (taskDescription.isEmpty() || taskDescription.length() > 200) {
                 throw new ParseException(Task.MESSAGE_CONSTRAINTS_TASK_DESCRIPTION);
             }
             editTaskDescriptor.setTaskDescription(taskDescription);

--- a/src/main/java/seedu/address/model/employee/Email.java
+++ b/src/main/java/seedu/address/model/employee/Email.java
@@ -73,12 +73,12 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return value.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/employee/Employee.java
+++ b/src/main/java/seedu/address/model/employee/Employee.java
@@ -129,7 +129,7 @@ public class Employee {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, position, tags, taskListStorage);
+        return Objects.hash(name, phone, email, department, position, tags, taskListStorage);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASK_NAME;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.EditTaskCommand.EditTaskDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.employee.Task;
 import seedu.address.testutil.EditTaskDescriptorBuilder;
 
@@ -128,6 +130,18 @@ public class EditTaskCommandParserTest {
     public void parse_duplicateDescriptionPrefix_failure() {
         assertParseFailure(parser, "1" + TASK_DESC_PRESENTATION + TASK_DESC_REPORT,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TASK_DESCRIPTION));
+    }
+
+    @Test
+    void parse_invalidTaskName_throwsParseException() {
+        String invalidTaskName = "1 task/" + "A".repeat(51) + " desc/" + VALID_TASK_DESCRIPTION_REPORT;
+        assertThrows(ParseException.class, () -> parser.parse(invalidTaskName));
+    }
+
+    @Test
+    void parse_invalidTaskDescription_throwsParseException() {
+        String invalidTaskDescription = "1 task/" + VALID_TASK_NAME_PRESENTATION + " desc/" + "A".repeat(201);
+        assertThrows(ParseException.class, () -> parser.parse(invalidTaskDescription));
     }
 
 

--- a/src/test/java/seedu/address/model/employee/EmailTest.java
+++ b/src/test/java/seedu/address/model/employee/EmailTest.java
@@ -78,6 +78,9 @@ public class EmailTest {
         // same object -> returns true
         assertTrue(email.equals(email));
 
+        // same email different case -> returns true
+        assertTrue(email.equals(new Email("Valid@Email")));
+
         // null -> returns false
         assertFalse(email.equals(null));
 

--- a/src/test/java/seedu/address/model/employee/EmailTest.java
+++ b/src/test/java/seedu/address/model/employee/EmailTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.employee;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -66,6 +67,11 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
         assertTrue(Email.isValidEmail("a".repeat(88) + "@example.com")); // exactly 100 characters
+    }
+
+    @Test
+    public void hashCode_sameEmailDifferentCase_equalHashCodes() {
+        assertEquals(new Email("valid@email").hashCode(), new Email("Valid@Email").hashCode());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/employee/PersonTest.java
+++ b/src/test/java/seedu/address/model/employee/PersonTest.java
@@ -105,4 +105,10 @@ public class PersonTest {
                 + ", department=" + ALICE.getDepartment() + ", tags=" + ALICE.getTags() + ", Tasks Assigned:=}";
         assertEquals(expected, ALICE.toString());
     }
+
+    @Test
+    public void hashCode_sameValues_equalHashCodes() {
+        Employee aliceCopy = new PersonBuilder(ALICE).build();
+        assertEquals(ALICE.hashCode(), aliceCopy.hashCode());
+    }
 }


### PR DESCRIPTION
### Summary 
- Enforced length constraints for task name and description in `EditTaskCommandParser`
- Updated `equals`  logic in `Email` to be case-insensitive such that duplicate emails only differing by letter casing are treated as duplicates 