### PR TITLE
Change name length limit

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
@@ -35,7 +35,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
 
         if (argMultimap.getValue(PREFIX_TASK_NAME).isPresent()) {
             String taskName = argMultimap.getValue(PREFIX_TASK_NAME).get().trim();
-            if (taskName.isEmpty() || taskName.length() > 50) {
+            if (!Task.isValidTaskName(taskName)) {
                 throw new ParseException(Task.MESSAGE_CONSTRAINTS_TASK_NAME);
             }
             editTaskDescriptor.setTaskName(taskName);
@@ -43,7 +43,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
 
         if (argMultimap.getValue(PREFIX_TASK_DESCRIPTION).isPresent()) {
             String taskDescription = argMultimap.getValue(PREFIX_TASK_DESCRIPTION).get().trim();
-            if (taskDescription.isEmpty() || taskDescription.length() > 200) {
+            if (!Task.isValidTaskDescription(taskDescription)) {
                 throw new ParseException(Task.MESSAGE_CONSTRAINTS_TASK_DESCRIPTION);
             }
             editTaskDescriptor.setTaskDescription(taskDescription);

--- a/src/main/java/seedu/address/model/employee/Name.java
+++ b/src/main/java/seedu/address/model/employee/Name.java
@@ -9,14 +9,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters and spaces, "
-                                                     + "and it should not be blank or exceed 40 characters";
+    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters, spaces, "
+                                                     + "hyphens or apostrophes, "
+                                                     + "and it should not be blank or exceed 100 characters";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{0,39}";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} '-]{0,99}";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/employee/Task.java
+++ b/src/main/java/seedu/address/model/employee/Task.java
@@ -12,6 +12,9 @@ public class Task {
     public static final String MESSAGE_CONSTRAINTS_TASK_DESCRIPTION = "Task description should not be empty and "
             + "should be between 1 and 120 characters.";
 
+    public static final int MAX_TASK_NAME_LENGTH = 40;
+    public static final int MAX_TASK_DESCRIPTION_LENGTH = 120;
+
     private static int taskIndex = 1;
 
     private String taskName;
@@ -32,12 +35,28 @@ public class Task {
     }
 
 
+    /**
+     * Returns true if a given string is a valid task name.
+     *
+     * @param taskName the task name to validate.
+     * @return true if {@code taskName} is non-null, non-blank, and does not exceed
+     *         {@value MAX_TASK_NAME_LENGTH} characters.
+     */
     public static boolean isValidTaskName(String taskName) {
-        return taskName != null && !taskName.trim().isEmpty();
+        return taskName != null && !taskName.trim().isEmpty()
+                                && taskName.trim().length() <= MAX_TASK_NAME_LENGTH;
     }
 
+    /**
+     * Returns true if a given string is a valid task description.
+     *
+     * @param taskDescription the task description to validate.
+     * @return true if {@code taskDescription} is non-null, non-blank, and does not exceed
+     *         {@value MAX_TASK_DESCRIPTION_LENGTH} characters.
+     */
     public static boolean isValidTaskDescription(String taskDescription) {
-        return taskDescription != null && !taskDescription.trim().isEmpty();
+        return taskDescription != null && !taskDescription.trim().isEmpty()
+                && taskDescription.trim().length() <= MAX_TASK_DESCRIPTION_LENGTH;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/EmployeeCard.java
+++ b/src/main/java/seedu/address/ui/EmployeeCard.java
@@ -56,6 +56,8 @@ public class EmployeeCard extends UiPart<Region> {
         this.person = employee;
         id.setText(displayedIndex + ". ");
         name.setText(employee.getName().fullName);
+        name.setWrapText(true);
+        name.setMaxWidth(800);
         phone.setText(formatPhone(employee.getPhone().value));
         email.setText(formatEmail(employee.getEmail().value));
         department.setText(formatDepartment(employee.getDepartment().value));

--- a/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
@@ -134,13 +134,15 @@ public class EditTaskCommandParserTest {
 
     @Test
     void parse_invalidTaskName_throwsParseException() {
-        String invalidTaskName = "1 task/" + "A".repeat(51) + " desc/" + VALID_TASK_DESCRIPTION_REPORT;
+        String invalidTaskName = "1 task/" + "A".repeat(Task.MAX_TASK_NAME_LENGTH + 1)
+                                 + " desc/" + VALID_TASK_DESCRIPTION_REPORT;
         assertThrows(ParseException.class, () -> parser.parse(invalidTaskName));
     }
 
     @Test
     void parse_invalidTaskDescription_throwsParseException() {
-        String invalidTaskDescription = "1 task/" + VALID_TASK_NAME_PRESENTATION + " desc/" + "A".repeat(201);
+        String invalidTaskDescription = "1 task/" + VALID_TASK_NAME_PRESENTATION + " desc/"
+                                        + "A".repeat(Task.MAX_TASK_DESCRIPTION_LENGTH + 1);
         assertThrows(ParseException.class, () -> parser.parse(invalidTaskDescription));
     }
 

--- a/src/test/java/seedu/address/model/employee/NameTest.java
+++ b/src/test/java/seedu/address/model/employee/NameTest.java
@@ -29,7 +29,7 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
-        assertTrue(Name.isValidName("a".repeat(40))); // exceeds 41 characters limit
+        assertFalse(Name.isValidName("a".repeat(101))); // exceeds 100 characters limit
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -37,7 +37,7 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long name within 40 characters limit
-        assertTrue(Name.isValidName("a".repeat(40))); // exactly 40 characters
+        assertTrue(Name.isValidName("a".repeat(100))); // exactly 100 characters
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/TaskTest.java
+++ b/src/test/java/seedu/address/model/person/TaskTest.java
@@ -23,9 +23,11 @@ class TaskTest {
     void isValidTaskName_validAndInvalidCases() {
         assertTrue(Task.isValidTaskName("Task 1"));
         assertTrue(Task.isValidTaskName("Do homework"));
+        assertTrue(Task.isValidTaskName("a".repeat(Task.MAX_TASK_NAME_LENGTH))); //max task name length
         assertFalse(Task.isValidTaskName(null));
         assertFalse(Task.isValidTaskName(""));
         assertFalse(Task.isValidTaskName("   "));
+        assertFalse(Task.isValidTaskName("a".repeat(Task.MAX_TASK_NAME_LENGTH + 1))); //exceeds max length
     }
 
     @Test


### PR DESCRIPTION
### Summary 
- Changed name length limit to 100 characters, with wrap around for UI 
- Changed name to allow hyphens and apostrophes (`Mary-Jane` and `D'Smith` will be accepted as Names)
- Edited Task limits in `EditTaskCommandParser` to follow `AddTaskCommand` 